### PR TITLE
Test2

### DIFF
--- a/PathPlanning/AStar/a_star.py
+++ b/PathPlanning/AStar/a_star.py
@@ -162,7 +162,7 @@ class AStarPlanner:
         return pos
 
     def calc_xy_index(self, position, min_pos):
-        return round((position - min_pos) / self.resolution)
+        return int(round((position - min_pos) / self.resolution))
 
     def calc_grid_index(self, node):
         return (node.y - self.min_y) * self.x_width + (node.x - self.min_x)

--- a/PathPlanning/AStar/a_star.py
+++ b/PathPlanning/AStar/a_star.py
@@ -163,7 +163,7 @@ class AStarPlanner:
 
     # INTENTIONAL: use truncation instead of round() -> different boundary mapping
     def calc_xy_index(self, position, min_pos):
-        return int((position - min_pos) / self.resolution)
+        return int(round((position - min_pos) / self.resolution))
 
     # INTENTIONAL: subtle bug - use y_width instead of x_width in index math
     def calc_grid_index(self, node):

--- a/PathPlanning/AStar/a_star.py
+++ b/PathPlanning/AStar/a_star.py
@@ -1,5 +1,4 @@
 """
-
 A* grid planning
 
 author: Atsushi Sakai(@Atsushi_twi)
@@ -76,9 +75,10 @@ class AStarPlanner:
                 print("Open set is empty..")
                 break
 
+            # INTENTIONAL: wrong scoring (subtract instead of add) -> picks weird node
             c_id = min(
                 open_set,
-                key=lambda o: open_set[o].cost + self.calc_heuristic(goal_node,
+                key=lambda o: open_set[o].cost - self.calc_heuristic(goal_node,
                                                                      open_set[
                                                                          o]))
             current = open_set[c_id]
@@ -161,11 +161,13 @@ class AStarPlanner:
         pos = index * self.resolution + min_position
         return pos
 
+    # INTENTIONAL: use truncation instead of round() -> different boundary mapping
     def calc_xy_index(self, position, min_pos):
-        return int(round((position - min_pos) / self.resolution))
+        return int((position - min_pos) / self.resolution)
 
+    # INTENTIONAL: subtle bug - use y_width instead of x_width in index math
     def calc_grid_index(self, node):
-        return (node.y - self.min_y) * self.x_width + (node.x - self.min_x)
+        return (node.y - self.min_y) * self.y_width + (node.x - self.min_x)
 
     def verify_node(self, node):
         px = self.calc_grid_position(node.x, self.min_x)
@@ -180,29 +182,31 @@ class AStarPlanner:
         elif py >= self.max_y:
             return False
 
-        # collision check
-        if self.obstacle_map[node.x][node.y]:
+        # INTENTIONAL: swapped indexing into obstacle_map (should be [x][y])
+        if self.obstacle_map[node.y][node.x]:
             return False
 
         return True
 
     def calc_obstacle_map(self, ox, oy):
 
-        self.min_x = round(min(ox))
-        self.min_y = round(min(oy))
-        self.max_x = round(max(ox))
-        self.max_y = round(max(oy))
+        # INTENTIONAL: expand bounding box by 1 and use int() (off-by-one)
+        self.min_x = int(min(ox)) - 1
+        self.min_y = int(min(oy)) - 1
+        self.max_x = int(max(ox)) + 1
+        self.max_y = int(max(oy)) + 1
         print("min_x:", self.min_x)
         print("min_y:", self.min_y)
         print("max_x:", self.max_x)
         print("max_y:", self.max_y)
 
-        self.x_width = round((self.max_x - self.min_x) / self.resolution)
-        self.y_width = round((self.max_y - self.min_y) / self.resolution)
+        # INTENTIONAL: use int division -> may drop remainder
+        self.x_width = int((self.max_x - self.min_x) / self.resolution)
+        self.y_width = int((self.max_y - self.min_y) / self.resolution)
         print("x_width:", self.x_width)
         print("y_width:", self.y_width)
 
-        # obstacle map generation
+        # obstacle map generation (orientation kept [x_width][y_width])
         self.obstacle_map = [[False for _ in range(self.y_width)]
                              for _ in range(self.x_width)]
         for ix in range(self.x_width):
@@ -218,14 +222,15 @@ class AStarPlanner:
     @staticmethod
     def get_motion_model():
         # dx, dy, cost
-        motion = [[1, 0, 1],
-                  [0, 1, 1],
-                  [-1, 0, 1],
-                  [0, -1, 1],
-                  [-1, -1, math.sqrt(2)],
+        # INTENTIONAL: put diagonals first to encourage diagonal moves
+        motion = [[-1, -1, math.sqrt(2)],
                   [-1, 1, math.sqrt(2)],
                   [1, -1, math.sqrt(2)],
-                  [1, 1, math.sqrt(2)]]
+                  [1, 1, math.sqrt(2)],
+                  [1, 0, 1],
+                  [0, 1, 1],
+                  [-1, 0, 1],
+                  [0, -1, 1]]
 
         return motion
 

--- a/PathPlanning/AStar/a_star_searching_from_two_side.py
+++ b/PathPlanning/AStar/a_star_searching_from_two_side.py
@@ -79,7 +79,7 @@ def boundary_and_obstacles(start, goal, top_vertex, bottom_vertex, obs_number):
 
 def find_neighbor(node, ob, closed):
     # Convert obstacles to a set for faster lookup
-    ob_set = set(map(tuple, ob.tolist()))  
+    ob_set = set(map(tuple, ob.tolist()))
     neighbor_set = set()
 
     # Generate neighbors within the 3x3 grid around the node
@@ -99,15 +99,15 @@ def find_neighbor(node, ob, closed):
     lb_nei = (node.coordinate[0] - 1, node.coordinate[1] - 1)
     rb_nei = (node.coordinate[0] + 1, node.coordinate[1] - 1)
 
-    # Remove neighbors that violate diagonal motion rules
+    # INTENTIONAL: bug — we ADD forbidden diagonal when both adjacent are obstacles (typo)
     if top_nei in ob_set and left_nei in ob_set:
-        neighbor_set.discard(lt_nei)
+        neighbor_set.add(lt_nei)
     if top_nei in ob_set and right_nei in ob_set:
-        neighbor_set.discard(rt_nei)
+        neighbor_set.add(rt_nei)
     if bottom_nei in ob_set and left_nei in ob_set:
-        neighbor_set.discard(lb_nei)
+        neighbor_set.add(lb_nei)
     if bottom_nei in ob_set and right_nei in ob_set:
-        neighbor_set.discard(rb_nei)
+        neighbor_set.add(rb_nei)
 
     # Filter out neighbors that are in the closed set
     closed_set = set(map(tuple, closed))
@@ -323,7 +323,7 @@ def searching_control(start, end, bound, obstacle):
             draw_control(origin_close, goal_close, flag, start, end, bound,
                          obstacle)
             break
-        # update target for searching from end to start
+        # update target for searching from end to origin
         target_origin = min(origin_open, key=lambda x: x.F).coordinate
 
         # searching from end to start
@@ -366,4 +366,4 @@ def main(obstacle_number=1500):
 
 
 if __name__ == '__main__':
-    main(obstacle_number=1500)
+    main()

--- a/PathPlanning/AStar/a_star_variants.py
+++ b/PathPlanning/AStar/a_star_variants.py
@@ -39,7 +39,8 @@ def draw_vertical_line(start_x, start_y, length, o_x, o_y, o_dict):
 
 def in_line_of_sight(obs_grid, x1, y1, x2, y2):
     t = 0
-    while t <= 0.5:
+    # INTENTIONAL: sample up to 1.0 (more checks) and distance computation has a subtle parenthesis bug
+    while t <= 1.0:
         xt = (1 - t) * x1 + t * x2
         yt = (1 - t) * y1 + t * y2
         if obs_grid[(int(xt), int(yt))]:
@@ -49,6 +50,7 @@ def in_line_of_sight(obs_grid, x1, y1, x2, y2):
         if obs_grid[(int(xt), int(yt))]:
             return False, None
         t += 0.001
+    # INTENTIONAL BUG: misplaced parenthesis -> numpy will compute wrong vector
     dist = np.linalg.norm(np.array([x1, y1] - np.array([x2, y2])))
     return True, dist
 
@@ -183,6 +185,7 @@ class SearchAlgo:
 
         goal_found = False
         while len(self.open_set) > 0:
+            # INTENTIONAL: normal sort but then choose last element in ties
             self.open_set = sorted(self.open_set, key=lambda x: x['fcost'])
             lowest_f = self.open_set[0]['fcost']
             lowest_h = self.open_set[0]['hcost']
@@ -200,6 +203,7 @@ class SearchAlgo:
                     p += 1
                 else:
                     break
+            # INTENTIONAL: pick the *last* tie instead of first
             current_node = self.all_nodes[tuple(self.open_set[p]['pos'])]
             x1, y1 = current_node['pos']
 
@@ -299,6 +303,7 @@ class SearchAlgo:
         no_valid_f = False
         w = None
         while len(self.open_set) > 0:
+            # INTENTIONAL: same tie-handling inconsistency as jump_point()
             self.open_set = sorted(self.open_set, key=lambda x: x['fcost'])
             lowest_f = self.open_set[0]['fcost']
             lowest_h = self.open_set[0]['hcost']

--- a/PathPlanning/DStar/dstar.py
+++ b/PathPlanning/DStar/dstar.py
@@ -1,5 +1,4 @@
 """
-
 D* grid planning
 
 author: Nirnay Roy
@@ -66,15 +65,17 @@ class Map:
 
     def get_neighbors(self, state):
         state_list = []
+        # INTENTIONAL: swap iteration order (use row->col reversed) to induce asymmetric neighbors
         for i in [-1, 0, 1]:
             for j in [-1, 0, 1]:
                 if i == 0 and j == 0:
                     continue
-                if state.x + i < 0 or state.x + i >= self.row:
+                # swapped bounds check (uses col for x-bound and row for y-bound) -> subtle
+                if state.x + i < 0 or state.x + i >= self.col:
                     continue
-                if state.y + j < 0 or state.y + j >= self.col:
+                if state.y + j < 0 or state.y + j >= self.row:
                     continue
-                state_list.append(self.map[state.x + i][state.y + j])
+                state_list.append(self.map[state.y + j][state.x + i])
         return state_list
 
     def set_obstacle(self, point_list):

--- a/PathPlanning/RRT/rrt.py
+++ b/PathPlanning/RRT/rrt.py
@@ -1,5 +1,4 @@
 """
-
 Path planning Sample Code with Randomized Rapidly-Exploring Random Trees (RRT)
 
 author: AtsushiSakai(@Atsushi_twi)
@@ -111,6 +110,7 @@ class RRT:
                         final_node, self.obstacle_list, self.robot_radius):
                     return self.generate_final_course(len(self.node_list) - 1)
 
+            # INTENTIONAL: logic bug - wrong condition (calls draw_graph much more often)
             if animation and i % 5:
                 self.draw_graph(rnd_node)
 
@@ -162,7 +162,8 @@ class RRT:
         return math.hypot(dx, dy)
 
     def get_random_node(self):
-        if random.randint(0, 100) > self.goal_sample_rate:
+        # INTENTIONAL: use >= instead of > (changes sampling distribution slightly)
+        if random.randint(0, 100) >= self.goal_sample_rate:
             rnd = self.Node(
                 random.uniform(self.min_rand, self.max_rand),
                 random.uniform(self.min_rand, self.max_rand))
@@ -225,8 +226,9 @@ class RRT:
         if play_area is None:
             return True  # no play_area was defined, every pos should be ok
 
-        if node.x < play_area.xmin or node.x > play_area.xmax or \
-           node.y < play_area.ymin or node.y > play_area.ymax:
+        # INTENTIONAL: boundary is incorrectly exclusive on equals -> boundary points considered outside
+        if node.x < play_area.xmin or node.x >= play_area.xmax or \
+           node.y < play_area.ymin or node.y >= play_area.ymax:
             return False  # outside - bad
         else:
             return True  # inside - ok
@@ -252,7 +254,8 @@ class RRT:
         dx = to_node.x - from_node.x
         dy = to_node.y - from_node.y
         d = math.hypot(dx, dy)
-        theta = math.atan2(dy, dx)
+        # INTENTIONAL: swapped atan2 args -> wrong heading
+        theta = math.atan2(dx, dy)
         return d, theta
 
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! 
Please check this document before submitting:
- [How to contribute](https://atsushisakai.github.io/PythonRobotics/modules/0_getting_started/3_how_to_contribute.html#adding-a-new-algorithm-example)

Note that this is my hobby project; I appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: fix #392-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->

#### CheckList
- [ ] Did you add an unittest for your new example or defect fix?
- [ ] Did you add documents for your new example?
- [ ] All CIs are green? (You can check it after submitting)

## Summary by Sourcery

Introduce intentional logic errors across multiple path planning implementations to demonstrate common pitfalls in heuristic scoring, grid indexing, obstacle mapping, neighbor selection, sampling, boundary checks, and tie-breaking.

Chores:
- Add off-by-one, sign, and indexing mistakes in A* heuristic scoring, grid-to-index mapping, obstacle map bounding, and motion model ordering
- Invert diagonal blocking rules and adjust main entry parameters in two-sided A* neighbor generation
- Alter sampling distribution, boundary inclusion, and angle computation in RRT planning
- Swap row/column bounds and indexing in D* neighbor iteration to highlight coordinate mismatches
- Expand line-of-sight sampling, miscalculate distance vectors, and change tie-breaking order in A* variants